### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -1,4 +1,6 @@
 name: Build and Publish to Docker Hub
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/AetherKnowledge/Safehub/security/code-scanning/2](https://github.com/AetherKnowledge/Safehub/security/code-scanning/2)

To fix the problem, we need to add an explicit `permissions` block to the workflow to restrict the GITHUB_TOKEN permissions. Since the workflow only needs source code access (for actions/checkout, to fetch the repo), and does not require write access for issues, pull requests, or other resources, the minimal safe default is to set:
```
permissions:
  contents: read
```
This block should be added at the top level of the workflow file (immediately after the `name:` and before `on:`) to apply to all jobs. No other permissions are required for the described steps. No methods, variable definitions, or imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
